### PR TITLE
Set logtostderr

### DIFF
--- a/cmd/sidecarinjector/main.go
+++ b/cmd/sidecarinjector/main.go
@@ -36,7 +36,7 @@ const (
 func main() {
 	glog.Info("api=main, reason='Starting generic sidecar injector ...'")
 
-	err := flag.CommandLine.Parse([]string{}) // This line is necessary to make flag think its run.
+	err := flag.CommandLine.Parse([]string{"--logtostderr"}) // This line is necessary to make flag think its run.
 	if err != nil {
 		glog.Errorf("api=main, reason=commandline.Parse, err=%v", err)
 		os.Exit(errorExitCode)


### PR DESCRIPTION
## What

- simple addition to have glog not log to a file

## Why

- In a kubernetes context the general use case will not want a container logging to a file on its filesystem. Ensure the logs are going to stderr.