### PR TITLE
Add fromYaml template function

### DIFF
--- a/cmd/sidecarinjector/main.go
+++ b/cmd/sidecarinjector/main.go
@@ -52,7 +52,11 @@ func main() {
 
 	// Sanity check for templateFile. Eligible fields https://salesforce.quip.com/pEW6A6AtpwRc
 	// TODO: move above doc to git wiki
-	sidecarConfigTemplate, err := template.New(filepath.Base(webhookConfig.SidecarConfigFile)).Delims(util.TemplateLeftDelimiter, util.TemplateRightDelimiter).ParseFiles(webhookConfig.SidecarConfigFile)
+	sidecarConfigTemplate, err :=
+		template.New(filepath.Base(webhookConfig.SidecarConfigFile)).
+			Delims(util.TemplateLeftDelimiter, util.TemplateRightDelimiter).
+			Funcs(sidecarconfig.SidecarTemplateExtraFuncs()).
+			ParseFiles(webhookConfig.SidecarConfigFile)
 	if err != nil {
 		glog.Errorf("api=main, reason=template.New, file=%q, err=%v", webhookConfig.SidecarConfigFile, err)
 		os.Exit(errorExitCode)

--- a/pkg/sidecarconfig/sidecarconfig.go
+++ b/pkg/sidecarconfig/sidecarconfig.go
@@ -17,6 +17,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/salesforce/generic-sidecar-injector/pkg/mutationconfig"
+	"github.com/salesforce/generic-sidecar-injector/pkg/templates"
 	"github.com/salesforce/generic-sidecar-injector/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,6 +191,7 @@ func TemplateSanityCheck(sidecarConfigTemplate *template.Template) error {
 				"rsyslog.k8s-integration.sfdc.com/test-volume-mounts": "test",
 				"rsyslog.k8s-integration.sfdc.com/log-volume-mounts":  "test",
 				"vault.k8s-integration.sfdc.com/vaultRole":            "test",
+				"vault.k8s-integration.sfdc.com/config":               "some:\n  - yaml\n  - array\nwith:\n  yaml: object",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -198,4 +200,10 @@ func TemplateSanityCheck(sidecarConfigTemplate *template.Template) error {
 	}
 	_, err := RenderTemplate(dummyPod, sidecarConfigTemplate)
 	return err
+}
+
+func SidecarTemplateExtraFuncs() template.FuncMap {
+	return template.FuncMap{
+		"fromYaml": templates.FromYAML,
+	}
 }

--- a/pkg/sidecarconfig/sidecarconfig.go
+++ b/pkg/sidecarconfig/sidecarconfig.go
@@ -185,13 +185,20 @@ func RenderTemplate(pod corev1.Pod, sidecarConfigTemplate *template.Template) (*
 
 // TemplateSanityCheck ensures given template has valid templated field
 func TemplateSanityCheck(sidecarConfigTemplate *template.Template) error {
+	const annotationValueAsYaml = `
+some:
+- yaml
+- array
+with:
+  yaml: object`
+
 	dummyPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"rsyslog.k8s-integration.sfdc.com/test-volume-mounts": "test",
 				"rsyslog.k8s-integration.sfdc.com/log-volume-mounts":  "test",
 				"vault.k8s-integration.sfdc.com/vaultRole":            "test",
-				"vault.k8s-integration.sfdc.com/config":               "some:\n  - yaml\n  - array\nwith:\n  yaml: object",
+				"vault.k8s-integration.sfdc.com/config":               annotationValueAsYaml,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/templates/funcs.go
+++ b/pkg/templates/funcs.go
@@ -1,0 +1,18 @@
+package templates
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// FromYAML decodes a YAML string into an interface{}. This allows injection templates to access
+// configs defined as YAML strings.
+func FromYAML(str string) (interface{}, error) {
+	var i interface{}
+
+	if err := yaml.Unmarshal([]byte(str), &i); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal yaml with error: %v. source: %q", err, str)
+	}
+	return i, nil
+}

--- a/pkg/templates/funcs_test.go
+++ b/pkg/templates/funcs_test.go
@@ -1,0 +1,59 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			"invalid yaml",
+			"'",
+			nil,
+			true,
+		},
+		{
+			"empty object",
+			"{}",
+			map[interface{}]interface{}{},
+			false,
+		},
+		{
+			"raw string",
+			"hello world",
+			"hello world",
+			false,
+		},
+		{
+			"array of strings",
+			`["hello", "goodbye"]`,
+			[]interface{}{"hello", "goodbye"},
+			false,
+		},
+		{
+			"array of objects",
+			`["hello", {}]`,
+			[]interface{}{"hello", map[interface{}]interface{}{}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FromYAML(tt.yaml)
+			if tt.wantErr {
+				require.Error(t, err, "Expected error unmarshalling yaml string")
+				return
+			}
+
+			require.NoError(t, err, "Unexpected error unmarshalling yaml string")
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/templates/funcs_test.go
+++ b/pkg/templates/funcs_test.go
@@ -43,6 +43,13 @@ func TestFromYAML(t *testing.T) {
 			[]interface{}{"hello", map[interface{}]interface{}{}},
 			false,
 		},
+		{
+			"top-level object",
+			`age: "23"
+hello: bar`,
+			map[interface{}]interface{}{"age": "23", "hello": "bar"},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
It is often convenient to have multiple related configurations for a sidecar injector grouped under a single annotation rather than splitting them up across multiple annotations.

Adding a `fromYaml` template function provides sidecar configuration templates the ability to introspect fields within annotations whose values are themselves yaml or json strings.