### PR TITLE
Parse flags from the native 'flag' package after parsing sidecar-injector flags

### DIFF
--- a/cmd/sidecarinjector/main.go
+++ b/cmd/sidecarinjector/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -34,7 +35,7 @@ const (
 func main() {
 	webhookConfig, err := config.NewWebhookConfig()
 	if err != nil {
-		glog.Errorf("api=main, reason=config.NewWebhookConfig, err=%v", err)
+		fmt.Fprintf(os.Stderr, "api=main, reason=config.NewWebhookConfig, err=%v\n", err)
 		os.Exit(errorExitCode)
 	}
 	if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {

--- a/cmd/sidecarinjector/main.go
+++ b/cmd/sidecarinjector/main.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -33,10 +32,6 @@ const (
 )
 
 func main() {
-	// This line is necessary to make glog happy
-	// TODO: move away from glog
-	flag.CommandLine.Parse([]string{})
-
 	webhookConfig, err := config.NewWebhookConfig()
 	if err != nil {
 		glog.Errorf("api=main, reason=config.NewWebhookConfig, err=%v", err)

--- a/pkg/injectionwebhook/config/config.go
+++ b/pkg/injectionwebhook/config/config.go
@@ -8,6 +8,8 @@
 package config
 
 import (
+	"flag"
+
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 )
@@ -37,9 +39,11 @@ func NewWebhookConfig() (*WebhookConfig, error) {
 func parse() (*WebhookConfig, error) {
 	c := &WebhookConfig{}
 	parser := flags.NewParser(c, flags.HelpFlag|flags.PrintErrors|flags.PassDoubleDash|flags.IgnoreUnknown)
-	_, err := parser.Parse()
+	extraArgs, err := parser.Parse()
 	if err != nil {
 		return nil, errors.Errorf("api=parse, err=%v", err)
 	}
+	// Parse any extra args for dependent packages that use "flag" (e.g., glog).
+	flag.CommandLine.Parse(extraArgs)
 	return c, nil
 }


### PR DESCRIPTION
Currently it is not possible for a webhook author to configure flags for packages that use the native `"flag"` import, because `main` always parses an empty set of flags:

https://github.com/salesforce/generic-sidecar-injector/blob/eea027d68335a45fae16b7e5f9d92692be4a4a99/cmd/sidecarinjector/main.go#L36-L38

This makes it impossible to adjust the [glog configuration](https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog.go#L38-L70) for the webhook, for example.

Update the flag parsing logic to parse any leftover flags using `flag.Parse` after `go-flags` has had its turn parsing sidecar-injector flags.