### PR TITLE
Deprecate old TLS versions and insecure ciphers by default

### DIFF
--- a/pkg/injectionwebhook/config/config.go
+++ b/pkg/injectionwebhook/config/config.go
@@ -24,6 +24,9 @@ type WebhookConfig struct {
 	SidecarConfigFile  string `long:"sidecar-config-file" required:"true" description:"file containing the sidecar container configuration"`
 	MutationConfigFile string `long:"mutation-config-file" required:"true" description:"file containing the mutation configuration"`
 	BuildInfoLabels    string `long:"build-info-labels" required:"false" description:"additional build info metric labels"`
+
+	// Flag to permit fallback to old, insecure TLS configurations.
+	AllowDeprecatedTLSConfig bool `long:"allow-deprecated-tls-config" required:"false" description:"permits use of deprecated TLS configuration (TLS 1.0/1.1, weak ciphers)"`
 }
 
 // NewWebhookConfig is a constructor for WebhookConfig

--- a/pkg/injectionwebhook/webhook.go
+++ b/pkg/injectionwebhook/webhook.go
@@ -274,6 +274,19 @@ func (whsvr *WebhookServer) Start() (chan bool, chan bool, error) {
 				return whsvr.certificateReloader.GetCertificate()
 			},
 		}
+		if !config.AllowDeprecatedTLSConfig {
+			tlsConfig.MinVersion = tls.VersionTLS12
+			tlsConfig.CipherSuites = []uint16{
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			}
+			tlsConfig.PreferServerCipherSuites = true
+		}
+
 		if config.CaFilePath != "" {
 			caCert, err := ioutil.ReadFile(config.CaFilePath)
 			if err != nil {


### PR DESCRIPTION
Go TLS defaults still permit TLS 1.0 and TLS 1.1, which have [been formally deprecated](https://datatracker.ietf.org/doc/rfc8996/).

Go TLS default configuration also permits many weaker cipher strenghts.

Mutating webhooks are, in general, only called from the kubernetes API server (itself a Go client), so there is limited compatibility concern beyond supporting old versions of k8s that were built with a go version older than go 1.13, which [added default support for TLS 1.3](https://golang.org/doc/go1.13#tls_1_3).

This change has been tested and verified on k8s 1.10, k8s 1.15, k8s 1.16, and k8s 1.17.

Before this change:
```
$ curl -k -vvv --ciphers rsa_aes_256_sha --tlsv1.0 <endpoint>
...
* SSL connection using TLS_RSA_WITH_AES_256_CBC_SHA
...
```

After:

```
$ curl -k -vvv --ciphers rsa_aes_256_sha --tlsv1.0 <endpoint>
...
* NSS error -12190 (SSL_ERROR_PROTOCOL_VERSION_ALERT)
* Peer reports incompatible or unsupported protocol version.
* Closing connection 0
curl: (35) Peer reports incompatible or unsupported protocol version.
...

$ curl -k -vvv --ciphers rsa_aes_256_sha --tlsv1.1 <endpoint>
...
* NSS error -12190 (SSL_ERROR_PROTOCOL_VERSION_ALERT)
* Peer reports incompatible or unsupported protocol version.
* Closing connection 0
curl: (35) Peer reports incompatible or unsupported protocol version.
...

$ curl -k -vvv --ciphers rsa_aes_256_sha --tlsv1.2 <endpoint>
...
* NSS error -12286 (SSL_ERROR_NO_CYPHER_OVERLAP)
* Cannot communicate securely with peer: no common encryption algorithm(s).
* Closing connection 0
curl: (35) Cannot communicate securely with peer: no common encryption algorithm(s).
...

$ curl -k -vvv --tlsv1.2 <endpoint>
...
* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
...

$ curl -k -vvv --tlsv1.3 <endpoint>
...
* SSL connection using TLS_AES_128_GCM_SHA256
...
```