### PR TITLE
Use Alpine For Docker Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1 AS build
+FROM golang:1-alpine AS build
 
 WORKDIR /sidecarinjector
 COPY go.mod go.sum ./
@@ -8,12 +8,14 @@ RUN go mod download
 COPY . ./
 COPY pkg ./pkg
 
+RUN apk --no-cache add git
+
 RUN GIT_HASH=$(git rev-parse --short HEAD) && GIT_TAG=$(git tag | tail -1) && \
     CGO_ENABLED=0 && GOOS=linux && GOARCH=amd64 && \
     echo "GIT_HASH=$GIT_HASH" && echo "GIT_TAG=$GIT_TAG" && \
     go build -ldflags  "-X 'github.com/salesforce/generic-sidecar-injector/pkg/metrics.gitHash=$GIT_HASH' -X 'github.com/salesforce/generic-sidecar-injector/pkg/metrics.gitTag=$GIT_TAG' -s" -installsuffix cgo -o sidecarinjector ./cmd/sidecarinjector
 
-FROM golang:1
+FROM golang:1-alpine
 COPY --from=build /sidecarinjector/sidecarinjector /sidecarinjector
 ENV PATH="/:${PATH}"
 CMD ["/sidecarinjector"]


### PR DESCRIPTION
Switches the base image from `golang:1` to `golang:1-alpine`. Changing the base image to alpine reduces the size of the image and the amount of dependency vulnerabilities in the image.